### PR TITLE
Support windows 7 (Fixes #12)

### DIFF
--- a/scripts/cdk3-virt.sh
+++ b/scripts/cdk3-virt.sh
@@ -32,11 +32,20 @@ if [ "$(get_os_platform)" == "win" ]; then
 	# check if Win32_Processor.VirtualizationFirmwareEnabled property exists
 	log_info "Checking if Win32_Processor.VirtualizationFirmwareEnabled property exists... "
     EXISTS="$(powershell.exe "@(gwmi -Class Win32_Processor)[0].psobject.properties.name -contains 'VirtualizationFirmwareEnabled'" | tr -d '\r\n')"
-    log_info "Is Virtualization on: $EXISTS"
+    log_info "Property exists: $EXISTS"
 	if [ "$EXISTS" == "True" ]; then
     	VIRTUALIZATION_ENABLED="$(powershell.exe "@(gwmi -Class Win32_Processor)[0] | Select -ExpandProperty VirtualizationFirmwareEnabled" | tr -d '\r\n')"
-	fi
-else 
+	else
+        if [ "$(is_windows7)" == "1" ]; then
+            log_info "OS is Windows 7"
+        	CPU_MODEL="$(powershell.exe "@(gwmi -Class Win32_Processor)[0] | Select -ExpandProperty Name" | tr -d '\r\n')"
+            log_info "CPU model: ${CPU_MODEL}"
+            if [[ ! ${CPU_MODEL} == *Haswell* ]]; then
+            	VIRTUALIZATION_ENABLED="True"
+            fi
+        fi
+    fi
+else
 	if [[ "$(lscpu | grep Virtualization:)" == *VT-x* ]]; then
     VIRTUALIZATION_ENABLED="True"
     fi

--- a/scripts/script-utils.sh
+++ b/scripts/script-utils.sh
@@ -136,3 +136,17 @@ function url_has_minishift {
 function http_status_ok {
     echo $(curl -Is -l ${1} | head -n 1 | grep -i http/1 | awk {'print $2'} | grep -E '2[0-9]{2}|3[0-9]{2}')
 }
+
+# check if underline os is windows 7, returns 1 if yes, 0 otherwise
+function is_windows7 {
+    if [ $(get_os_platform) == "win" ]; then
+        OS_NAME="$(powershell.exe "@(gwmi -Class Win32_OperatingSystem)[0] | Select -ExpandProperty Caption" | tr -d '\r\n' | grep -o "Windows 7")"
+        if [ "$OS_NAME" == "Windows 7" ]; then
+            echo 1
+        else
+            echo 0
+        fi
+    else
+        echo 0
+    fi
+}


### PR DESCRIPTION
Workaround for issue #12. Checks cpu model name, if haswell, assume that virtualization is not allowed.